### PR TITLE
fix free() -> lsmash_free() in order to prevent crash on different C runtime

### DIFF
--- a/common/libavsmash.c
+++ b/common/libavsmash.c
@@ -507,7 +507,7 @@ static int prepare_new_decoder_configuration
                 if( lsmash_get_mp4sys_decoder_specific_info( mdp, &cs_data, &cs_data_size ) )
                     goto fail;
                 int ret = queue_extradata( config, cs_data, cs_data_size );
-                free( cs_data );
+                lsmash_free( cs_data );
                 if( ret )
                     goto fail;
             }


### PR DESCRIPTION
Fix crash when built using dynamic linking to lsmash DLL.
Since current setup scenario only supports static linking to liblsmash.a, this cannot be not an issue.
However, it is rather trivial to build LSMASHSource.dll using dynamic linking to liblsmash and other libav/ffmpeg related DLLs by tweaking extlib.cpp, so it would better to be using lsmash_free() here.
