### PR TITLE
Fix VapourSynth error handling and other issues

### DIFF
--- a/AviUtl/VSHelper.h
+++ b/AviUtl/VSHelper.h
@@ -1,24 +1,12 @@
-/*
+/*****************************************************************************
 * Copyright (c) 2012-2015 Fredrik Mellbin
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in
-* all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-* THE SOFTWARE.
-*/
+* --- Legal stuff ---
+* This program is free software. It comes without any warranty, to
+* the extent permitted by applicable law. You can redistribute it
+* and/or modify it under the terms of the Do What The Fuck You Want
+* To Public License, Version 2, as published by Sam Hocevar. See
+* http://sam.zoy.org/wtfpl/COPYING for more details.
+*****************************************************************************/
 
 #ifndef VSHELPER_H
 #define VSHELPER_H
@@ -27,6 +15,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 #ifdef _WIN32
 #include <malloc.h>
 #endif
@@ -57,9 +46,13 @@
 #define VSMAX(a,b) ((a) > (b) ? (a) : (b))
 #define VSMIN(a,b) ((a) > (b) ? (b) : (a))
 
-#ifdef __cplusplus
+#ifdef __cplusplus 
 /* A nicer templated malloc for all the C++ users out there */
-template<class T>
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1900)
+template<typename T=void>
+#else
+template<typename T>
+#endif
 static inline T* vs_aligned_malloc(size_t size, size_t alignment) {
 #ifdef _WIN32
     return (T*)_aligned_malloc(size, alignment);
@@ -88,6 +81,13 @@ static inline int isSameFormat(const VSVideoInfo *v1, const VSVideoInfo *v2) {
 
 /* multiplies and divides a rational number, such as a frame duration, in place and reduces the result */
 static inline void muldivRational(int64_t *num, int64_t *den, int64_t mul, int64_t div) {
+    /* do nothing if the rational number is invalid */
+    if (!*den)
+        return;
+
+    /* nobody wants to accidentally divide by zero */
+    assert(div);
+
     int64_t a, b;
     *num *= mul;
     *den *= div;
@@ -104,6 +104,35 @@ static inline void muldivRational(int64_t *num, int64_t *den, int64_t mul, int64
     *den /= a;
 }
 
+/* reduces a rational number */
+static inline void vs_normalizeRational(int64_t *num, int64_t *den) {
+	muldivRational(num, den, 1, 1);
+}
+
+/* add two rational numbers and reduces the result */
+static inline void vs_addRational(int64_t *num, int64_t *den, int64_t addnum, int64_t addden) {
+    /* do nothing if the rational number is invalid */
+    if (!*den)
+        return;
+
+    /* nobody wants to accidentally add an invalid rational number */
+    assert(addden);
+
+	if (*den == addden) {
+		*num += addnum;
+	} else {
+		int64_t temp = addden;
+		addnum *= *den;
+		addden *= *den;
+		*num *= temp;
+		*den *= temp;
+
+		*num += addnum;
+
+		vs_normalizeRational(num, den);
+	}
+}
+
 /* converts an int64 to int with saturation, useful to silence warnings when reading int properties among other things */
 static inline int int64ToIntS(int64_t i) {
     if (i > INT_MAX)
@@ -113,14 +142,14 @@ static inline int int64ToIntS(int64_t i) {
     else return (int)i;
 }
 
-static inline void vs_bitblt(void *dstp, int dst_stride, const void *srcp, int src_stride, int row_size, int height) {
-    if (height > 0) {
-        if (src_stride == dst_stride && src_stride == row_size) {
+static inline void vs_bitblt(void *dstp, int dst_stride, const void *srcp, int src_stride, size_t row_size, size_t height) {
+    if (height) {
+        if (src_stride == dst_stride && src_stride == (int)row_size) {
             memcpy(dstp, srcp, row_size * height);
         } else {
-            int i;
-            uint8_t *srcp8 = (uint8_t *)srcp;
+            const uint8_t *srcp8 = (const uint8_t *)srcp;
             uint8_t *dstp8 = (uint8_t *)dstp;
+            size_t i;
             for (i = 0; i < height; i++) {
                 memcpy(dstp8, srcp8, row_size);
                 srcp8 += src_stride;

--- a/VapourSynth/VapourSynth.h
+++ b/VapourSynth/VapourSynth.h
@@ -24,14 +24,20 @@
 #include <stdint.h>
 
 #define VAPOURSYNTH_API_MAJOR 3
-#define VAPOURSYNTH_API_MINOR 2
+#define VAPOURSYNTH_API_MINOR 4
 #define VAPOURSYNTH_API_VERSION ((VAPOURSYNTH_API_MAJOR << 16) | (VAPOURSYNTH_API_MINOR))
 
 /* Convenience for C++ users. */
 #ifdef __cplusplus
 #    define VS_EXTERN_C extern "C"
+#    if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1900)
+#        define VS_NOEXCEPT noexcept
+#    else
+#        define VS_NOEXCEPT
+#    endif
 #else
 #    define VS_EXTERN_C
+#    define VS_NOEXCEPT
 #endif
 
 #if defined(_WIN32) && !defined(_WIN64)
@@ -148,8 +154,9 @@ typedef struct VSFormat {
 } VSFormat;
 
 typedef enum VSNodeFlags {
-    nfNoCache = 1,
-    nfIsCache = 2
+    nfNoCache    = 1,
+    nfIsCache    = 2,
+    nfMakeLinear = 4 /* api 3.3 */
 } VSNodeFlags;
 
 typedef enum VSPropTypes {
@@ -189,7 +196,7 @@ typedef struct VSVideoInfo {
     int64_t fpsDen;
     int width;
     int height;
-    int numFrames;
+    int numFrames; /* api 3.2 - no longer allowed to be 0 */
     int flags;
 } VSVideoInfo;
 
@@ -225,100 +232,103 @@ typedef void (VS_CC *VSFrameDoneCallback)(void *userData, const VSFrameRef *f, i
 typedef void (VS_CC *VSMessageHandler)(int msgType, const char *msg, void *userData);
 
 struct VSAPI {
-    VSCore *(VS_CC *createCore)(int threads);
-    void (VS_CC *freeCore)(VSCore *core);
-    const VSCoreInfo *(VS_CC *getCoreInfo)(VSCore *core);
+    VSCore *(VS_CC *createCore)(int threads) VS_NOEXCEPT;
+    void (VS_CC *freeCore)(VSCore *core) VS_NOEXCEPT;
+    const VSCoreInfo *(VS_CC *getCoreInfo)(VSCore *core) VS_NOEXCEPT;
 
-    const VSFrameRef *(VS_CC *cloneFrameRef)(const VSFrameRef *f);
-    VSNodeRef *(VS_CC *cloneNodeRef)(VSNodeRef *node);
-    VSFuncRef *(VS_CC *cloneFuncRef)(VSFuncRef *f);
+    const VSFrameRef *(VS_CC *cloneFrameRef)(const VSFrameRef *f) VS_NOEXCEPT;
+    VSNodeRef *(VS_CC *cloneNodeRef)(VSNodeRef *node) VS_NOEXCEPT;
+    VSFuncRef *(VS_CC *cloneFuncRef)(VSFuncRef *f) VS_NOEXCEPT;
 
-    void (VS_CC *freeFrame)(const VSFrameRef *f);
-    void (VS_CC *freeNode)(VSNodeRef *node);
-    void (VS_CC *freeFunc)(VSFuncRef *f);
+    void (VS_CC *freeFrame)(const VSFrameRef *f) VS_NOEXCEPT;
+    void (VS_CC *freeNode)(VSNodeRef *node) VS_NOEXCEPT;
+    void (VS_CC *freeFunc)(VSFuncRef *f) VS_NOEXCEPT;
 
-    VSFrameRef *(VS_CC *newVideoFrame)(const VSFormat *format, int width, int height, const VSFrameRef *propSrc, VSCore *core);
-    VSFrameRef *(VS_CC *copyFrame)(const VSFrameRef *f, VSCore *core);
-    void (VS_CC *copyFrameProps)(const VSFrameRef *src, VSFrameRef *dst, VSCore *core);
+    VSFrameRef *(VS_CC *newVideoFrame)(const VSFormat *format, int width, int height, const VSFrameRef *propSrc, VSCore *core) VS_NOEXCEPT;
+    VSFrameRef *(VS_CC *copyFrame)(const VSFrameRef *f, VSCore *core) VS_NOEXCEPT;
+    void (VS_CC *copyFrameProps)(const VSFrameRef *src, VSFrameRef *dst, VSCore *core) VS_NOEXCEPT;
 
-    void (VS_CC *registerFunction)(const char *name, const char *args, VSPublicFunction argsFunc, void *functionData, VSPlugin *plugin);
-    VSPlugin *(VS_CC *getPluginById)(const char *identifier, VSCore *core);
-    VSPlugin *(VS_CC *getPluginByNs)(const char *ns, VSCore *core);
-    VSMap *(VS_CC *getPlugins)(VSCore *core);
-    VSMap *(VS_CC *getFunctions)(VSPlugin *plugin);
-    void (VS_CC *createFilter)(const VSMap *in, VSMap *out, const char *name, VSFilterInit init, VSFilterGetFrame getFrame, VSFilterFree free, int filterMode, int flags, void *instanceData, VSCore *core);
-    void (VS_CC *setError)(VSMap *map, const char *errorMessage); /* use to signal errors outside filter getframe functions */
-    const char *(VS_CC *getError)(const VSMap *map); /* use to query errors, returns 0 if no error */
-    void (VS_CC *setFilterError)(const char *errorMessage, VSFrameContext *frameCtx); /* use to signal errors in the filter getframe function */
-    VSMap *(VS_CC *invoke)(VSPlugin *plugin, const char *name, const VSMap *args);
+    void (VS_CC *registerFunction)(const char *name, const char *args, VSPublicFunction argsFunc, void *functionData, VSPlugin *plugin) VS_NOEXCEPT;
+    VSPlugin *(VS_CC *getPluginById)(const char *identifier, VSCore *core) VS_NOEXCEPT;
+    VSPlugin *(VS_CC *getPluginByNs)(const char *ns, VSCore *core) VS_NOEXCEPT;
+    VSMap *(VS_CC *getPlugins)(VSCore *core) VS_NOEXCEPT;
+    VSMap *(VS_CC *getFunctions)(VSPlugin *plugin) VS_NOEXCEPT;
+    void (VS_CC *createFilter)(const VSMap *in, VSMap *out, const char *name, VSFilterInit init, VSFilterGetFrame getFrame, VSFilterFree free, int filterMode, int flags, void *instanceData, VSCore *core) VS_NOEXCEPT;
+    void (VS_CC *setError)(VSMap *map, const char *errorMessage) VS_NOEXCEPT; /* use to signal errors outside filter getframe functions */
+    const char *(VS_CC *getError)(const VSMap *map) VS_NOEXCEPT; /* use to query errors, returns 0 if no error */
+    void (VS_CC *setFilterError)(const char *errorMessage, VSFrameContext *frameCtx) VS_NOEXCEPT; /* use to signal errors in the filter getframe function */
+    VSMap *(VS_CC *invoke)(VSPlugin *plugin, const char *name, const VSMap *args) VS_NOEXCEPT;
 
-    const VSFormat *(VS_CC *getFormatPreset)(int id, VSCore *core);
-    const VSFormat *(VS_CC *registerFormat)(int colorFamily, int sampleType, int bitsPerSample, int subSamplingW, int subSamplingH, VSCore *core);
+    const VSFormat *(VS_CC *getFormatPreset)(int id, VSCore *core) VS_NOEXCEPT;
+    const VSFormat *(VS_CC *registerFormat)(int colorFamily, int sampleType, int bitsPerSample, int subSamplingW, int subSamplingH, VSCore *core) VS_NOEXCEPT;
 
-    const VSFrameRef *(VS_CC *getFrame)(int n, VSNodeRef *node, char *errorMsg, int bufSize); /* do never use inside a filter's getframe function, for external applications using the core as a library or for requesting frames in a filter constructor */
-    void (VS_CC *getFrameAsync)(int n, VSNodeRef *node, VSFrameDoneCallback callback, void *userData); /* do never use inside a filter's getframe function, for external applications using the core as a library or for requesting frames in a filter constructor */
-    const VSFrameRef *(VS_CC *getFrameFilter)(int n, VSNodeRef *node, VSFrameContext *frameCtx); /* only use inside a filter's getframe function */
-    void (VS_CC *requestFrameFilter)(int n, VSNodeRef *node, VSFrameContext *frameCtx); /* only use inside a filter's getframe function */
-    void (VS_CC *queryCompletedFrame)(VSNodeRef **node, int *n, VSFrameContext *frameCtx); /* only use inside a filter's getframe function */
-    void (VS_CC *releaseFrameEarly)(VSNodeRef *node, int n, VSFrameContext *frameCtx); /* only use inside a filter's getframe function */
+    const VSFrameRef *(VS_CC *getFrame)(int n, VSNodeRef *node, char *errorMsg, int bufSize) VS_NOEXCEPT; /* do never use inside a filter's getframe function, for external applications using the core as a library or for requesting frames in a filter constructor */
+    void (VS_CC *getFrameAsync)(int n, VSNodeRef *node, VSFrameDoneCallback callback, void *userData) VS_NOEXCEPT; /* do never use inside a filter's getframe function, for external applications using the core as a library or for requesting frames in a filter constructor */
+    const VSFrameRef *(VS_CC *getFrameFilter)(int n, VSNodeRef *node, VSFrameContext *frameCtx) VS_NOEXCEPT; /* only use inside a filter's getframe function */
+    void (VS_CC *requestFrameFilter)(int n, VSNodeRef *node, VSFrameContext *frameCtx) VS_NOEXCEPT; /* only use inside a filter's getframe function */
+    void (VS_CC *queryCompletedFrame)(VSNodeRef **node, int *n, VSFrameContext *frameCtx) VS_NOEXCEPT; /* only use inside a filter's getframe function */
+    void (VS_CC *releaseFrameEarly)(VSNodeRef *node, int n, VSFrameContext *frameCtx) VS_NOEXCEPT; /* only use inside a filter's getframe function */
 
-    int (VS_CC *getStride)(const VSFrameRef *f, int plane);
-    const uint8_t *(VS_CC *getReadPtr)(const VSFrameRef *f, int plane);
-    uint8_t *(VS_CC *getWritePtr)(VSFrameRef *f, int plane);
+    int (VS_CC *getStride)(const VSFrameRef *f, int plane) VS_NOEXCEPT;
+    const uint8_t *(VS_CC *getReadPtr)(const VSFrameRef *f, int plane) VS_NOEXCEPT;
+    uint8_t *(VS_CC *getWritePtr)(VSFrameRef *f, int plane) VS_NOEXCEPT;
 
-    VSFuncRef *(VS_CC *createFunc)(VSPublicFunction func, void *userData, VSFreeFuncData free, VSCore *core, const VSAPI *vsapi);
-    void (VS_CC *callFunc)(VSFuncRef *func, const VSMap *in, VSMap *out, VSCore *core, const VSAPI *vsapi); /* core and vsapi arguments are completely ignored, they only remain to preserve ABI */
+    VSFuncRef *(VS_CC *createFunc)(VSPublicFunction func, void *userData, VSFreeFuncData free, VSCore *core, const VSAPI *vsapi) VS_NOEXCEPT;
+    void (VS_CC *callFunc)(VSFuncRef *func, const VSMap *in, VSMap *out, VSCore *core, const VSAPI *vsapi) VS_NOEXCEPT; /* core and vsapi arguments are completely ignored, they only remain to preserve ABI */
 
     /* property access functions */
-    VSMap *(VS_CC *createMap)(void);
-    void (VS_CC *freeMap)(VSMap *map);
-    void (VS_CC *clearMap)(VSMap *map);
+    VSMap *(VS_CC *createMap)(void) VS_NOEXCEPT;
+    void (VS_CC *freeMap)(VSMap *map) VS_NOEXCEPT;
+    void (VS_CC *clearMap)(VSMap *map) VS_NOEXCEPT;
 
-    const VSVideoInfo *(VS_CC *getVideoInfo)(VSNodeRef *node);
-    void (VS_CC *setVideoInfo)(const VSVideoInfo *vi, int numOutputs, VSNode *node);
-    const VSFormat *(VS_CC *getFrameFormat)(const VSFrameRef *f);
-    int (VS_CC *getFrameWidth)(const VSFrameRef *f, int plane);
-    int (VS_CC *getFrameHeight)(const VSFrameRef *f, int plane);
-    const VSMap *(VS_CC *getFramePropsRO)(const VSFrameRef *f);
-    VSMap *(VS_CC *getFramePropsRW)(VSFrameRef *f);
+    const VSVideoInfo *(VS_CC *getVideoInfo)(VSNodeRef *node) VS_NOEXCEPT;
+    void (VS_CC *setVideoInfo)(const VSVideoInfo *vi, int numOutputs, VSNode *node) VS_NOEXCEPT;
+    const VSFormat *(VS_CC *getFrameFormat)(const VSFrameRef *f) VS_NOEXCEPT;
+    int (VS_CC *getFrameWidth)(const VSFrameRef *f, int plane) VS_NOEXCEPT;
+    int (VS_CC *getFrameHeight)(const VSFrameRef *f, int plane) VS_NOEXCEPT;
+    const VSMap *(VS_CC *getFramePropsRO)(const VSFrameRef *f) VS_NOEXCEPT;
+    VSMap *(VS_CC *getFramePropsRW)(VSFrameRef *f) VS_NOEXCEPT;
 
-    int (VS_CC *propNumKeys)(const VSMap *map);
-    const char *(VS_CC *propGetKey)(const VSMap *map, int index);
-    int (VS_CC *propNumElements)(const VSMap *map, const char *key);
-    char (VS_CC *propGetType)(const VSMap *map, const char *key);
+    int (VS_CC *propNumKeys)(const VSMap *map) VS_NOEXCEPT;
+    const char *(VS_CC *propGetKey)(const VSMap *map, int index) VS_NOEXCEPT;
+    int (VS_CC *propNumElements)(const VSMap *map, const char *key) VS_NOEXCEPT;
+    char (VS_CC *propGetType)(const VSMap *map, const char *key) VS_NOEXCEPT;
 
-    int64_t(VS_CC *propGetInt)(const VSMap *map, const char *key, int index, int *error);
-    double(VS_CC *propGetFloat)(const VSMap *map, const char *key, int index, int *error);
-    const char *(VS_CC *propGetData)(const VSMap *map, const char *key, int index, int *error);
-    int (VS_CC *propGetDataSize)(const VSMap *map, const char *key, int index, int *error);
-    VSNodeRef *(VS_CC *propGetNode)(const VSMap *map, const char *key, int index, int *error);
-    const VSFrameRef *(VS_CC *propGetFrame)(const VSMap *map, const char *key, int index, int *error);
-    VSFuncRef *(VS_CC *propGetFunc)(const VSMap *map, const char *key, int index, int *error);
+    int64_t(VS_CC *propGetInt)(const VSMap *map, const char *key, int index, int *error) VS_NOEXCEPT;
+    double(VS_CC *propGetFloat)(const VSMap *map, const char *key, int index, int *error) VS_NOEXCEPT;
+    const char *(VS_CC *propGetData)(const VSMap *map, const char *key, int index, int *error) VS_NOEXCEPT;
+    int (VS_CC *propGetDataSize)(const VSMap *map, const char *key, int index, int *error) VS_NOEXCEPT;
+    VSNodeRef *(VS_CC *propGetNode)(const VSMap *map, const char *key, int index, int *error) VS_NOEXCEPT;
+    const VSFrameRef *(VS_CC *propGetFrame)(const VSMap *map, const char *key, int index, int *error) VS_NOEXCEPT;
+    VSFuncRef *(VS_CC *propGetFunc)(const VSMap *map, const char *key, int index, int *error) VS_NOEXCEPT;
 
-    int (VS_CC *propDeleteKey)(VSMap *map, const char *key);
-    int (VS_CC *propSetInt)(VSMap *map, const char *key, int64_t i, int append);
-    int (VS_CC *propSetFloat)(VSMap *map, const char *key, double d, int append);
-    int (VS_CC *propSetData)(VSMap *map, const char *key, const char *data, int size, int append);
-    int (VS_CC *propSetNode)(VSMap *map, const char *key, VSNodeRef *node, int append);
-    int (VS_CC *propSetFrame)(VSMap *map, const char *key, const VSFrameRef *f, int append);
-    int (VS_CC *propSetFunc)(VSMap *map, const char *key, VSFuncRef *func, int append);
+    int (VS_CC *propDeleteKey)(VSMap *map, const char *key) VS_NOEXCEPT;
+    int (VS_CC *propSetInt)(VSMap *map, const char *key, int64_t i, int append) VS_NOEXCEPT;
+    int (VS_CC *propSetFloat)(VSMap *map, const char *key, double d, int append) VS_NOEXCEPT;
+    int (VS_CC *propSetData)(VSMap *map, const char *key, const char *data, int size, int append) VS_NOEXCEPT;
+    int (VS_CC *propSetNode)(VSMap *map, const char *key, VSNodeRef *node, int append) VS_NOEXCEPT;
+    int (VS_CC *propSetFrame)(VSMap *map, const char *key, const VSFrameRef *f, int append) VS_NOEXCEPT;
+    int (VS_CC *propSetFunc)(VSMap *map, const char *key, VSFuncRef *func, int append) VS_NOEXCEPT;
 
-    /* mixed functions added after API R3.0 */
-    int64_t (VS_CC *setMaxCacheSize)(int64_t bytes, VSCore *core);
-    int (VS_CC *getOutputIndex)(VSFrameContext *frameCtx);
-    VSFrameRef *(VS_CC *newVideoFrame2)(const VSFormat *format, int width, int height, const VSFrameRef **planeSrc, const int *planes, const VSFrameRef *propSrc, VSCore *core);
-    void (VS_CC *setMessageHandler)(VSMessageHandler handler, void *userData);
-    int (VS_CC *setThreadCount)(int threads, VSCore *core);
+    int64_t (VS_CC *setMaxCacheSize)(int64_t bytes, VSCore *core) VS_NOEXCEPT;
+    int (VS_CC *getOutputIndex)(VSFrameContext *frameCtx) VS_NOEXCEPT;
+    VSFrameRef *(VS_CC *newVideoFrame2)(const VSFormat *format, int width, int height, const VSFrameRef **planeSrc, const int *planes, const VSFrameRef *propSrc, VSCore *core) VS_NOEXCEPT;
+    void (VS_CC *setMessageHandler)(VSMessageHandler handler, void *userData) VS_NOEXCEPT;
+    int (VS_CC *setThreadCount)(int threads, VSCore *core) VS_NOEXCEPT;
 
-    const char *(VS_CC *getPluginPath)(const VSPlugin *plugin);
+    const char *(VS_CC *getPluginPath)(const VSPlugin *plugin) VS_NOEXCEPT;
 
-    const int64_t *(VS_CC *propGetIntArray)(const VSMap *map, const char *key, int *error);
-    const double *(VS_CC *propGetFloatArray)(const VSMap *map, const char *key, int *error);
+    /* api 3.1 */
+    const int64_t *(VS_CC *propGetIntArray)(const VSMap *map, const char *key, int *error) VS_NOEXCEPT;
+    const double *(VS_CC *propGetFloatArray)(const VSMap *map, const char *key, int *error) VS_NOEXCEPT;
 
-    int (VS_CC *propSetIntArray)(VSMap *map, const char *key, const int64_t *i, int size);
-    int (VS_CC *propSetFloatArray)(VSMap *map, const char *key, const double *d, int size);
+    int (VS_CC *propSetIntArray)(VSMap *map, const char *key, const int64_t *i, int size) VS_NOEXCEPT;
+    int (VS_CC *propSetFloatArray)(VSMap *map, const char *key, const double *d, int size) VS_NOEXCEPT;
+
+    /* api 3.4 */
+    void (VS_CC *logMessage)(int msgType, const char *msg) VS_NOEXCEPT;
 };
 
-VS_API(const VSAPI *) getVapourSynthAPI(int version);
+VS_API(const VSAPI *) getVapourSynthAPI(int version) VS_NOEXCEPT;
 
 #endif /* VAPOURSYNTH_H */

--- a/VapourSynth/libavsmash_source.c
+++ b/VapourSynth/libavsmash_source.c
@@ -408,6 +408,6 @@ void VS_CC vs_libavsmashsource_create( const VSMap *in, VSMap *out, void *user_d
         return;
     }
     lsmash_discard_boxes( libavsmash_video_get_root( vdhp ) );
-    vsapi->createFilter( in, out, "LibavSMASHSource", vs_filter_init, vs_filter_get_frame, vs_filter_free, fmSerial, 0, hp, core );
+    vsapi->createFilter( in, out, "LibavSMASHSource", vs_filter_init, vs_filter_get_frame, vs_filter_free, fmUnordered, nfMakeLinear, hp, core );
     return;
 }

--- a/VapourSynth/libavsmash_source.c
+++ b/VapourSynth/libavsmash_source.c
@@ -162,15 +162,14 @@ static void set_frame_properties
     vsapi->propSetInt( props, "_SARNum", av_frame->sample_aspect_ratio.num, paReplace );
     vsapi->propSetInt( props, "_SARDen", av_frame->sample_aspect_ratio.den, paReplace );
     /* Color format */
-    if( ctx )
-    {
-        if (ctx->color_range != AVCOL_RANGE_UNSPECIFIED)
-            vsapi->propSetInt(props, "_ColorRange", ctx->color_range == AVCOL_RANGE_MPEG, paReplace);
-        vsapi->propSetInt( props, "_Primaries",   ctx->color_primaries,                 paReplace );
-        vsapi->propSetInt( props, "_Transfer",    ctx->color_trc,                       paReplace );
-        vsapi->propSetInt( props, "_Matrix",      ctx->colorspace,                      paReplace );
-        if  ctx->chroma_sample_location > 0 )
-            vsapi->propSetInt(Props, "_ChromaLocation", Frame->ChromaLocation - 1, paReplace);
+    if ( ctx ) {
+        if ( ctx->color_range != AVCOL_RANGE_UNSPECIFIED )
+            vsapi->propSetInt( props, "_ColorRange", ctx->color_range == AVCOL_RANGE_MPEG, paReplace );
+        vsapi->propSetInt( props, "_Primaries", ctx->color_primaries, paReplace );
+        vsapi->propSetInt( props, "_Transfer", ctx->color_trc, paReplace );
+        vsapi->propSetInt( props, "_Matrix", ctx->colorspace, paReplace );
+        if ( ctx->chroma_sample_location > 0 )
+            vsapi->propSetInt( props, "_ChromaLocation", ctx->chroma_sample_location - 1, paReplace );
     }
     /* Picture type */
     char pict_type = av_get_picture_type_char( av_frame->pict_type );
@@ -178,8 +177,8 @@ static void set_frame_properties
     /* BFF or TFF */
     int field_based = 0;
     if ( av_frame->interlaced_frame )
-        field_based = (av_frame->top_field_first ? 2 : 1);
-    vsapi->propSetInt(Props, "_FieldBased", field_based, paReplace);
+        field_based = ( av_frame->top_field_first ? 2 : 1 );
+    vsapi->propSetInt( props, "_FieldBased", field_based, paReplace );
 }
 
 static int prepare_video_decoding

--- a/VapourSynth/libavsmash_source.c
+++ b/VapourSynth/libavsmash_source.c
@@ -258,7 +258,10 @@ static const VSFrameRef *VS_CC vs_filter_get_frame( int n, int activation_reason
     libavsmash_video_decode_handler_t *vdhp = hp->vdhp;
     libavsmash_video_output_handler_t *vohp = hp->vohp;
     if( libavsmash_video_get_error( vdhp ) )
-        return vsapi->newVideoFrame( vi->format, vi->width, vi->height, NULL, core );
+    {
+        vsapi->setFilterError( "lsmas: failed to output a video frame.", frame_ctx );
+        return NULL;
+    }
     /* Set up VapourSynth error handler. */
     vs_basic_handler_t vsbh = { 0 };
     vsbh.out       = NULL;
@@ -273,14 +276,17 @@ static const VSFrameRef *VS_CC vs_filter_get_frame( int n, int activation_reason
     vs_vohp->core      = core;
     vs_vohp->vsapi     = vsapi;
     if( libavsmash_video_get_frame( vdhp, vohp, sample_number ) < 0 )
+    {
+        vsapi->setFilterError( "lsmas: failed to output a video frame.", frame_ctx );
         return NULL;
+    }
     /* Output video frame. */
     AVFrame    *av_frame = libavsmash_video_get_frame_buffer( vdhp );
     VSFrameRef *vs_frame = make_frame( vohp, av_frame );
     if( !vs_frame )
     {
         vsapi->setFilterError( "lsmas: failed to output a video frame.", frame_ctx );
-        return vsapi->newVideoFrame( vi->format, vi->width, vi->height, NULL, core );
+        return NULL;
     }
     set_frame_properties( vdhp, vi, av_frame, vs_frame, sample_number, vsapi );
     return vs_frame;

--- a/VapourSynth/libavsmash_source.c
+++ b/VapourSynth/libavsmash_source.c
@@ -164,30 +164,22 @@ static void set_frame_properties
     /* Color format */
     if( ctx )
     {
-        vsapi->propSetInt( props, "_ColorRange",  ctx->color_range != AVCOL_RANGE_JPEG, paReplace );
+        if (ctx->color_range != AVCOL_RANGE_UNSPECIFIED)
+            vsapi->propSetInt(props, "_ColorRange", ctx->color_range == AVCOL_RANGE_MPEG, paReplace);
         vsapi->propSetInt( props, "_Primaries",   ctx->color_primaries,                 paReplace );
         vsapi->propSetInt( props, "_Transfer",    ctx->color_trc,                       paReplace );
         vsapi->propSetInt( props, "_Matrix",      ctx->colorspace,                      paReplace );
-        int chroma_loc;
-        switch( ctx->chroma_sample_location )
-        {
-            case AVCHROMA_LOC_LEFT       : chroma_loc = 0;  break;
-            case AVCHROMA_LOC_CENTER     : chroma_loc = 1;  break;
-            case AVCHROMA_LOC_TOPLEFT    : chroma_loc = 2;  break;
-            case AVCHROMA_LOC_TOP        : chroma_loc = 3;  break;
-            case AVCHROMA_LOC_BOTTOMLEFT : chroma_loc = 4;  break;
-            case AVCHROMA_LOC_BOTTOM     : chroma_loc = 5;  break;
-            default                      : chroma_loc = -1; break;
-        }
-        if( chroma_loc != -1 )
-            vsapi->propSetInt( props, "_ChromaLocation", chroma_loc, paReplace );
+        if  ctx->chroma_sample_location > 0 )
+            vsapi->propSetInt(Props, "_ChromaLocation", Frame->ChromaLocation - 1, paReplace);
     }
     /* Picture type */
     char pict_type = av_get_picture_type_char( av_frame->pict_type );
     vsapi->propSetData( props, "_PictType", &pict_type, 1, paReplace );
     /* BFF or TFF */
-    if( av_frame->interlaced_frame )
-        vsapi->propSetInt( props, "_FieldBased", av_frame->top_field_first ? 2 : 1, paReplace );
+    int field_based = 0;
+    if ( av_frame->interlaced_frame )
+        field_based = (av_frame->top_field_first ? 2 : 1);
+    vsapi->propSetInt(Props, "_FieldBased", field_based, paReplace);
 }
 
 static int prepare_video_decoding

--- a/VapourSynth/lwlibav_source.c
+++ b/VapourSynth/lwlibav_source.c
@@ -383,6 +383,6 @@ void VS_CC vs_lwlibavsource_create( const VSMap *in, VSMap *out, void *user_data
         vs_filter_free( hp, core, vsapi );
         return;
     }
-    vsapi->createFilter( in, out, "LWLibavSource", vs_filter_init, vs_filter_get_frame, vs_filter_free, fmSerial, 0, hp, core );
+    vsapi->createFilter( in, out, "LWLibavSource", vs_filter_init, vs_filter_get_frame, vs_filter_free, fmUnordered, nfMakeLinear, hp, core );
     return;
 }

--- a/VapourSynth/lwlibav_source.c
+++ b/VapourSynth/lwlibav_source.c
@@ -224,7 +224,10 @@ static const VSFrameRef *VS_CC vs_filter_get_frame( int n, int activation_reason
     lwlibav_video_decode_handler_t *vdhp = hp->vdhp;
     lwlibav_video_output_handler_t *vohp = hp->vohp;
     if( lwlibav_video_get_error( vdhp ) )
-        return vsapi->newVideoFrame( vi->format, vi->width, vi->height, NULL, core );
+    {
+        vsapi->setFilterError( "lsmas: failed to output a video frame.", frame_ctx );
+        return NULL;
+    }
     /* Set up VapourSynth error handler. */
     vs_basic_handler_t vsbh = { 0 };
     vsbh.out       = NULL;
@@ -239,14 +242,17 @@ static const VSFrameRef *VS_CC vs_filter_get_frame( int n, int activation_reason
     vs_vohp->core      = core;
     vs_vohp->vsapi     = vsapi;
     if( lwlibav_video_get_frame( vdhp, vohp, frame_number ) < 0 )
+    {
+        vsapi->setFilterError( "lsmas: failed to output a video frame.", frame_ctx );
         return NULL;
+    }
     /* Output the video frame. */
     AVFrame    *av_frame = lwlibav_video_get_frame_buffer( vdhp );
     VSFrameRef *vs_frame = make_frame( vohp, av_frame );
     if( !vs_frame )
     {
         vsapi->setFilterError( "lsmas: failed to output a video frame.", frame_ctx );
-        return vsapi->newVideoFrame( vi->format, vi->width, vi->height, NULL, core );
+        return NULL;
     }
     set_frame_properties( vdhp, vi, av_frame, vs_frame, vsapi );
     return vs_frame;

--- a/VapourSynth/lwlibav_source.c
+++ b/VapourSynth/lwlibav_source.c
@@ -149,23 +149,23 @@ static void set_frame_properties
     vsapi->propSetInt( props, "_DurationNum", vi->fpsDen, paReplace );
     vsapi->propSetInt( props, "_DurationDen", vi->fpsNum, paReplace );
     /* Color format */
-    if (ctx) {
-        if (ctx->color_range != AVCOL_RANGE_UNSPECIFIED)
-            vsapi->propSetInt(props, "_ColorRange", ctx->color_range == AVCOL_RANGE_MPEG, paReplace);
-        vsapi->propSetInt(props, "_Primaries", ctx->color_primaries, paReplace);
-        vsapi->propSetInt(props, "_Transfer", ctx->color_trc, paReplace);
-        vsapi->propSetInt(props, "_Matrix", ctx->colorspace, paReplace);
-        if  ctx->chroma_sample_location > 0 )
-        vsapi->propSetInt(Props, "_ChromaLocation", Frame->ChromaLocation - 1, paReplace);
+    if ( ctx ) {
+        if ( ctx->color_range != AVCOL_RANGE_UNSPECIFIED )
+            vsapi->propSetInt( props, "_ColorRange", ctx->color_range == AVCOL_RANGE_MPEG, paReplace );
+        vsapi->propSetInt( props, "_Primaries", ctx->color_primaries, paReplace );
+        vsapi->propSetInt( props, "_Transfer", ctx->color_trc, paReplace );
+        vsapi->propSetInt( props, "_Matrix", ctx->colorspace, paReplace );
+        if ( ctx->chroma_sample_location > 0 )
+            vsapi->propSetInt( props, "_ChromaLocation", ctx->chroma_sample_location - 1, paReplace );
     }
     /* Picture type */
     char pict_type = av_get_picture_type_char( av_frame->pict_type );
     vsapi->propSetData( props, "_PictType", &pict_type, 1, paReplace );
     /* BFF or TFF */
     int field_based = 0;
-    if (av_frame->interlaced_frame)
-        field_based = (av_frame->top_field_first ? 2 : 1);
-    vsapi->propSetInt(Props, "_FieldBased", field_based, paReplace);
+    if ( av_frame->interlaced_frame )
+        field_based = ( av_frame->top_field_first ? 2 : 1 );
+    vsapi->propSetInt( props, "_FieldBased", field_based, paReplace );
 }
 
 static int prepare_video_decoding

--- a/VapourSynth/lwlibav_source.c
+++ b/VapourSynth/lwlibav_source.c
@@ -149,32 +149,23 @@ static void set_frame_properties
     vsapi->propSetInt( props, "_DurationNum", vi->fpsDen, paReplace );
     vsapi->propSetInt( props, "_DurationDen", vi->fpsNum, paReplace );
     /* Color format */
-    if( ctx )
-    {
-        vsapi->propSetInt( props, "_ColorRange",  ctx->color_range != AVCOL_RANGE_JPEG, paReplace );
-        vsapi->propSetInt( props, "_Primaries",   ctx->color_primaries,                 paReplace );
-        vsapi->propSetInt( props, "_Transfer",    ctx->color_trc,                       paReplace );
-        vsapi->propSetInt( props, "_Matrix",      ctx->colorspace,                      paReplace );
-        int chroma_loc;
-        switch( ctx->chroma_sample_location )
-        {
-            case AVCHROMA_LOC_LEFT       : chroma_loc = 0;  break;
-            case AVCHROMA_LOC_CENTER     : chroma_loc = 1;  break;
-            case AVCHROMA_LOC_TOPLEFT    : chroma_loc = 2;  break;
-            case AVCHROMA_LOC_TOP        : chroma_loc = 3;  break;
-            case AVCHROMA_LOC_BOTTOMLEFT : chroma_loc = 4;  break;
-            case AVCHROMA_LOC_BOTTOM     : chroma_loc = 5;  break;
-            default                      : chroma_loc = -1; break;
-        }
-        if( chroma_loc != -1 )
-            vsapi->propSetInt( props, "_ChromaLocation", chroma_loc, paReplace );
+    if (ctx) {
+        if (ctx->color_range != AVCOL_RANGE_UNSPECIFIED)
+            vsapi->propSetInt(props, "_ColorRange", ctx->color_range == AVCOL_RANGE_MPEG, paReplace);
+        vsapi->propSetInt(props, "_Primaries", ctx->color_primaries, paReplace);
+        vsapi->propSetInt(props, "_Transfer", ctx->color_trc, paReplace);
+        vsapi->propSetInt(props, "_Matrix", ctx->colorspace, paReplace);
+        if  ctx->chroma_sample_location > 0 )
+        vsapi->propSetInt(Props, "_ChromaLocation", Frame->ChromaLocation - 1, paReplace);
     }
     /* Picture type */
     char pict_type = av_get_picture_type_char( av_frame->pict_type );
     vsapi->propSetData( props, "_PictType", &pict_type, 1, paReplace );
     /* BFF or TFF */
-    if( av_frame->interlaced_frame )
-        vsapi->propSetInt( props, "_FieldBased", av_frame->top_field_first ? 2 : 1, paReplace );
+    int field_based = 0;
+    if (av_frame->interlaced_frame)
+        field_based = (av_frame->top_field_first ? 2 : 1);
+    vsapi->propSetInt(Props, "_FieldBased", field_based, paReplace);
 }
 
 static int prepare_video_decoding


### PR DESCRIPTION
You must set an error when returning NULL. And never return a frame after setting an error.

Added header update and set proper flags for the filters.