### PR TITLE
VapourSynth/video_output: Fix BGR24 input

### DIFF
--- a/VapourSynth/video_output.c
+++ b/VapourSynth/video_output.c
@@ -329,6 +329,7 @@ static const component_reorder_t *get_component_reorder( enum AVPixelFormat av_o
             { AV_PIX_FMT_GBRP9LE,     {  1,  2,  0, -1 } },
             { AV_PIX_FMT_GBRP10LE,    {  1,  2,  0, -1 } },
             { AV_PIX_FMT_GBRP16LE,    {  1,  2,  0, -1 } },
+            { AV_PIX_FMT_BGR24,       {  2,  1,  0, -1 } },
             { AV_PIX_FMT_RGB24,       {  0,  1,  2, -1 } },
             { AV_PIX_FMT_ARGB,        {  1,  2,  3,  0 } },
             { AV_PIX_FMT_RGBA,        {  0,  1,  2,  3 } },


### PR DESCRIPTION
BGR24なフォーマットの動画を読み込んだ時、 get_component_reorder関数 にBGR24の項目が無いため崩れた画像で読み込まれる問題を修正するものです。
BGR24なフォーマットの動画はAviUtlを使い無圧縮のaviファイルとして出力することで作成しました。

お忙しいと思われますが確認の方お願いできますか？
プルリクエストは初めてなので手違いや無作法がございましたらご指摘お願いします。