### PR TITLE
VapourSynth/video_output: Fix crash when read unexpected format

### DIFF
--- a/VapourSynth/video_output.c
+++ b/VapourSynth/video_output.c
@@ -486,6 +486,8 @@ static int determine_colorspace_conversion
     *output_pixel_format = fmt_conv_required
                          ? vs_to_av_output_pixel_format( vs_vohp->vs_output_pixel_format )
                          : input_pixel_format;
+    if( *output_pixel_format == AV_PIX_FMT_NONE )
+        return -1;
     vs_vohp->component_reorder = get_component_reorder( *output_pixel_format );
     int av_output_flags = av_pix_fmt_desc_get( *output_pixel_format )->flags;
     return set_frame_maker( vs_vohp, (av_output_flags & AV_PIX_FMT_FLAG_PLANAR) && (av_output_flags & AV_PIX_FMT_FLAG_RGB) );


### PR DESCRIPTION
determine_colorspace_conversion関数の問題を修正するものです。

再現方法は、以下のコマンドで作成したファイルをformatオプションを指定せずに読み込むことです。
`ffmpeg -i input -c:v ffv1 -pix_fmt bgr0 output.mkv`
本来は、 "lsmas: bgr0 is not supported" と返しエラー返すべきところがクラッシュします。

原因は以下だと思われます。
determine_colorspace_conversion 関数の中の conversion_table 変数と入力ファイルのフォーマットが一致しない時、
*output_pixel_format が AV_PIX_FMT_NONE のまま av_pix_fmt_desc_get関数 に渡され NULL が返ってきます。
そのまま NULL から flags を引っ張り出そうとしてアクセス違反が起こっていると思われます。

*output_pixel_format に AV_PIX_FMT_NONE が入ってる時点ですぐにエラーを返して関数を抜けてしまうことで対処できると思われます。

ffmpeg/libavのAPIに私は疎いので修正の仕方が正しいか確認していただけませんか？